### PR TITLE
fix: AttributeError: 'dict' object has no attribute 'foobar'

### DIFF
--- a/aiida_dummy/__init__.py
+++ b/aiida_dummy/__init__.py
@@ -53,7 +53,7 @@ class DummyParser(Parser):
 
         try:
             folder = self.retrieved
-        except NotExistent:
+        except exceptions.NotExistent:
             return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
 
         self.logger.warning('Parsing dummy output %s', str(kwargs))

--- a/aiida_dummy/__init__.py
+++ b/aiida_dummy/__init__.py
@@ -36,7 +36,8 @@ class DummyWorkChain(WorkChain):
             assert self.ctx[key].is_finished_ok
 
     def finalize(self):
-        self.outputs.foobar = random.randint(1, 100)
+        self.ctx.foobar = Int(random.randint(1, 100))
+        self.out("foobar", self.ctx.foobar)
         self.report('DummyWorkChain finished...')
 
 


### PR DESCRIPTION
Fix error:
```
File "/app/aiida-dummy/aiida_dummy/__init__.py", line 43, in finalize
  self.outputs.foobar = random.randint(1, 100)
  ^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'foobar'
```

Used `aiida.orm.Int` type instead of `int` because otherwise it won't pass validation.
Saved to the context before output to prevent another error about returing of unstored value.

@blokhin @akvatol Please, take a look.